### PR TITLE
:rotating_light: Fix compilation error for apple clang 15.0.7

### DIFF
--- a/lib/bill/bill/sat/solver/glucose.hpp
+++ b/lib/bill/bill/sat/solver/glucose.hpp
@@ -1576,10 +1576,13 @@ static inline double Glucose::cpuTime(void) {
 
 #ifndef _WIN32
 
-static inline double Glucose::realTime() {
-  struct timeval tv;
-  gettimeofday(&tv, NULL);
-  return (double)tv.tv_sec + (double) tv.tv_usec / 1000000; }
+static inline double Glucose::realTime()
+{
+  const auto duration = std::chrono::system_clock::now().time_since_epoch();
+  const auto microsec = duration_cast<std::chrono::microseconds>(duration).count();
+  return static_cast<double>(microsec) / 1e6;
+}
+
 #endif
 #endif
 /***************************************************************************************[SolverTypes.h]

--- a/lib/bill/bill/sat/solver/glucose.hpp
+++ b/lib/bill/bill/sat/solver/glucose.hpp
@@ -38,6 +38,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #endif
 
 #include <limits.h>
+#include <chrono>
 
 #ifndef PRIu64
 #define PRIu64 "lu"
@@ -1574,11 +1575,11 @@ static inline double Glucose::cpuTime(void) {
 #endif
 
 #ifndef _WIN32
-// Laurent: I know that this will not compile directly under Windows... sorry for that
+
 static inline double Glucose::realTime() {
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
-    return (double)tv.tv_sec + (double) tv.tv_usec / 1000000; }
+  struct timeval tv;
+  gettimeofday(&tv, NULL);
+  return (double)tv.tv_sec + (double) tv.tv_usec / 1000000; }
 #endif
 #endif
 /***************************************************************************************[SolverTypes.h]

--- a/lib/bill/bill/sat/solver/glucose.hpp
+++ b/lib/bill/bill/sat/solver/glucose.hpp
@@ -1575,14 +1575,12 @@ static inline double Glucose::cpuTime(void) {
 #endif
 
 #ifndef _WIN32
-
 static inline double Glucose::realTime()
 {
   const auto duration = std::chrono::system_clock::now().time_since_epoch();
   const auto microsec = duration_cast<std::chrono::microseconds>(duration).count();
   return static_cast<double>(microsec) / 1e6;
 }
-
 #endif
 #endif
 /***************************************************************************************[SolverTypes.h]

--- a/lib/bill/bill/sat/solver/glucose.hpp
+++ b/lib/bill/bill/sat/solver/glucose.hpp
@@ -1575,6 +1575,7 @@ static inline double Glucose::cpuTime(void) {
 #endif
 
 #ifndef _WIN32
+// Using std::chrono to avoid compilation errors with Apple Clang 15.0.7
 static inline double Glucose::realTime()
 {
   const auto duration = std::chrono::system_clock::now().time_since_epoch();


### PR DESCRIPTION
This PR reimplements ``Glucose::realTime()`` to fix the compilation error for apple clang 15.0.7.