### PR TITLE
:sparkles: Feat(Diag): Save the final msg to aigverse

### DIFF
--- a/lib/lorina/lorina/aiger.hpp
+++ b/lib/lorina/lorina/aiger.hpp
@@ -547,7 +547,7 @@ static std::regex fairness( R"(^f(\d+) (.*)$)" );
     }
 
     const auto index = std::atol( std::string( tokens[0u] ).c_str() ) / 2u;
-    if ( !check_index_validity( index, 2 * _i + 2, 2 * _m + 1 ) )
+    if ( !check_index_validity( index, _i + 1, _m + 1 ) )
     {
       if ( diag )
       {
@@ -556,7 +556,7 @@ static std::regex fairness( R"(^f(\d+) (.*)$)" );
       return return_code::parse_error;
     }
     const auto next_lit = std::atol( std::string( tokens[1u] ).c_str() );
-    if ( !check_index_validity( next_lit, index + 1, 2 * _m + 1 ) )
+    if ( !check_index_validity( next_lit, index, _m + 1 ) )
     {
       if ( diag )
       {

--- a/lib/lorina/lorina/aiger.hpp
+++ b/lib/lorina/lorina/aiger.hpp
@@ -452,7 +452,7 @@ static std::regex fairness( R"(^f(\d+) (.*)$)" );
  */
 [[nodiscard]] inline bool check_index_validity( long index, uint64_t l_bound, uint64_t u_bound )
 {
-  if ( index < 0 || index < static_cast<long>(l_bound) || index > static_cast<long>(u_bound) )
+  if ( index < 0 || index < static_cast<long>( l_bound ) || index > static_cast<long>( u_bound ) )
   {
     return false;
   }
@@ -522,6 +522,10 @@ static std::regex fairness( R"(^f(\d+) (.*)$)" );
     const auto index = std::atol( line.c_str() );
     if ( !check_index_validity( index, 2, 2 * _m + 1 ) )
     {
+      if ( diag )
+      {
+        diag->report( diag_id::ERR_AIGER_INPUT ).add_argument( line );
+      }
       return return_code::parse_error;
     }
     reader.on_input( i, index );
@@ -543,13 +547,21 @@ static std::regex fairness( R"(^f(\d+) (.*)$)" );
     }
 
     const auto index = std::atol( std::string( tokens[0u] ).c_str() ) / 2u;
-    if ( !check_index_validity( index, 0, _m ) )
+    if ( !check_index_validity( index, 2 * _i + 2, 2 * _m + 1 ) )
     {
+      if ( diag )
+      {
+        diag->report( diag_id::ERR_AIGER_LATCH_DECLARATION ).add_argument( tokens[0u] );
+      }
       return return_code::parse_error;
     }
     const auto next_lit = std::atol( std::string( tokens[1u] ).c_str() );
-    if ( !check_index_validity( next_lit, 2, 2 * _m + 1 ) )
+    if ( !check_index_validity( next_lit, index + 1, 2 * _m + 1 ) )
     {
+      if ( diag )
+      {
+        diag->report( diag_id::ERR_AIGER_LATCH_DECLARATION ).add_argument( tokens[1u] );
+      }
       return return_code::parse_error;
     }
 
@@ -574,8 +586,12 @@ static std::regex fairness( R"(^f(\d+) (.*)$)" );
   {
     detail::getline( in, line );
     const auto lit = std::atol( line.c_str() );
-    if ( !check_index_validity( lit, 2, 2 * _m + 1 ) )
+    if ( !check_index_validity( lit, 2 * ( _i + _l ), 2 * _m + 1 ) )
     {
+      if ( diag )
+      {
+        diag->report( diag_id::ERR_AIGER_LATCH_DECLARATION ).add_argument( line );
+      }
       return return_code::parse_error;
     }
     reader.on_output( i, lit );

--- a/lib/lorina/lorina/diagnostics.hpp
+++ b/lib/lorina/lorina/diagnostics.hpp
@@ -123,7 +123,7 @@ private:
    *
    * \param original_diag_ids_args All pairs of the (id, message)
    */
-  void collect_messages( std::vector<std::pair<diag_id, std::vector<std::string>>> original_diag_ids_args );
+  void collect_messages( const std::vector<std::pair<diag_id, std::vector<std::string>>>& original_diag_ids_args );
 
 protected:
   diagnostic_consumer *client_ = nullptr;  /*!< Diagnostic client. */
@@ -275,6 +275,7 @@ inline uint64_t diagnostic_engine::get_num_diagnostics() const
 
 inline std::string diagnostic_engine::get_all_messages()
 {
+  all_messages.clear();
   collect_messages( original_diag_ids_args );
   return all_messages;
 }
@@ -353,7 +354,7 @@ inline void diagnostic_engine::collect_single_msg( diag_id id, std::vector<std::
     original_diag_ids_args.push_back( collects_ids_args );
 }
 
-inline void diagnostic_engine::collect_messages( std::vector<std::pair<diag_id, std::vector<std::string>>> original_diag_ids_args )
+inline void diagnostic_engine::collect_messages( const std::vector<std::pair<diag_id, std::vector<std::string>>>& original_diag_ids_args )
 {
   for ( auto i = 0; i < original_diag_ids_args.size(); i++ )
   {

--- a/lib/lorina/lorina/diagnostics.hpp
+++ b/lib/lorina/lorina/diagnostics.hpp
@@ -33,11 +33,11 @@
 #pragma once
 
 #include <cassert>
+#include <fmt/color.h>
+#include <fmt/format.h>
 #include <iostream>
 #include <map>
 #include <vector>
-#include <fmt/format.h>
-#include <fmt/color.h>
 
 namespace lorina
 {
@@ -69,7 +69,7 @@ public:
    *
    * \param client Diagnostic client
    */
-  explicit diagnostic_engine( diagnostic_consumer *client );
+  explicit diagnostic_engine( diagnostic_consumer* client );
 
   /*! \brief Creates a diagnostic builder.
    *
@@ -123,16 +123,16 @@ private:
    *
    * \param original_diag_ids_args All pairs of the (id, message)
    */
-  void collect_messages( const std::vector<std::pair<diag_id, std::vector<std::string>>>& original_diag_ids_args );
+  void collect_messages( std::vector<std::pair<diag_id, std::vector<std::string>>> const& original_diag_ids_args );
 
 protected:
-  diagnostic_consumer *client_ = nullptr;  /*!< Diagnostic client. */
-  std::vector<desc_type> custom_diag_info; /*!< Custom diagnostics. */
+  diagnostic_consumer* client_ = nullptr;       /*!< Diagnostic client. */
+  std::vector<desc_type> custom_diag_info;      /*!< Custom diagnostics. */
   std::map<desc_type, diag_id> custom_diag_ids; /*!< Map from custom ID to diagnostic. */
-  mutable uint64_t num_diagnostics{0};
-  std::vector<std::pair<diag_id, std::vector<std::string>>> original_diag_ids_args;
-  std::string all_messages;
-}; /* diagnostic_engine */
+  mutable uint64_t num_diagnostics{ 0 };
+  std::vector<std::pair<diag_id, std::vector<std::string>>> original_diag_ids_args; /*!< Diagnostic id and corresponding collected args. */
+  std::string all_messages;                                                         /*!< Get all the messages. */
+};                                                                                  /* diagnostic_engine */
 
 /*! \brief A builder for diagnostics.
  *
@@ -160,10 +160,10 @@ public:
   inline diagnostic_builder& add_argument( std::string const& s );
 
 private:
-  diagnostic_engine& engine_; /*!< diagnostic engine */
-  diag_id id_; /*!< id of diagnostic */
+  diagnostic_engine& engine_;     /*!< diagnostic engine */
+  diag_id id_;                    /*!< id of diagnostic */
   std::vector<std::string> args_; /*!< arguments for diagnostic */
-}; /* diagnostic_builder */
+};                                /* diagnostic_builder */
 
 /*! \brief A consumer for diagnostics. */
 class diagnostic_consumer
@@ -203,42 +203,42 @@ public:
     case diagnostic_level::ignore:
       break;
     case diagnostic_level::note:
-      {
-        fmt::print( stdout, fmt::emphasis::bold | fg( fmt::terminal_color::bright_green ), "[i]" );
-        fmt::print( stdout, fmt::emphasis::bold | fg( fmt::color::white ), " {}\n", message );
-      }
-      break;
+    {
+      fmt::print( stdout, fmt::emphasis::bold | fg( fmt::terminal_color::bright_green ), "[i]" );
+      fmt::print( stdout, fmt::emphasis::bold | fg( fmt::color::white ), " {}\n", message );
+    }
+    break;
     case diagnostic_level::remark:
-      {
-        fmt::print( stderr, fmt::emphasis::bold | fg( fmt::terminal_color::bright_green ), "[I]" );
-        fmt::print( stderr, fmt::emphasis::bold | fg( fmt::color::white ), " {}\n", message );
-      }
-      break;
+    {
+      fmt::print( stderr, fmt::emphasis::bold | fg( fmt::terminal_color::bright_green ), "[I]" );
+      fmt::print( stderr, fmt::emphasis::bold | fg( fmt::color::white ), " {}\n", message );
+    }
+    break;
     case diagnostic_level::warning:
-      {
-        fmt::print( stderr, fmt::emphasis::bold | fg( fmt::terminal_color::bright_magenta ),"[w]" );
-        fmt::print( stderr, fmt::emphasis::bold | fg( fmt::color::white ), " {}\n", message );
-      }
-      break;
+    {
+      fmt::print( stderr, fmt::emphasis::bold | fg( fmt::terminal_color::bright_magenta ), "[w]" );
+      fmt::print( stderr, fmt::emphasis::bold | fg( fmt::color::white ), " {}\n", message );
+    }
+    break;
     case diagnostic_level::error:
-      {
-        fmt::print( stderr, fmt::emphasis::bold | fg( fmt::terminal_color::bright_red ), "[e]" );
-        fmt::print( stderr, fmt::emphasis::bold | fg( fmt::color::white ), " {}\n", message );
-      }
-      break;
+    {
+      fmt::print( stderr, fmt::emphasis::bold | fg( fmt::terminal_color::bright_red ), "[e]" );
+      fmt::print( stderr, fmt::emphasis::bold | fg( fmt::color::white ), " {}\n", message );
+    }
+    break;
     case diagnostic_level::fatal:
     default:
-      {
-        fmt::print( stderr, fmt::emphasis::bold | fg( fmt::terminal_color::bright_red ), "[E]" );
-        fmt::print( stderr, fmt::emphasis::bold | fg( fmt::color::white ), " {}\n", message );
-      }
-      break;
+    {
+      fmt::print( stderr, fmt::emphasis::bold | fg( fmt::terminal_color::bright_red ), "[E]" );
+      fmt::print( stderr, fmt::emphasis::bold | fg( fmt::color::white ), " {}\n", message );
+    }
+    break;
     }
   }
 };
 
 inline diagnostic_builder::diagnostic_builder( diagnostic_engine& engine, diag_id id )
-  : engine_( engine ), id_( id )
+    : engine_( engine ), id_( id )
 {
 }
 
@@ -254,15 +254,15 @@ inline diagnostic_builder& diagnostic_builder::add_argument( std::string const& 
   return *this;
 }
 
-inline diagnostic_engine::diagnostic_engine( diagnostic_consumer *client )
-  : client_( client )
+inline diagnostic_engine::diagnostic_engine( diagnostic_consumer* client )
+    : client_( client )
 {
 }
 
 inline diag_id diagnostic_engine::create_id( diagnostic_level level, std::string const& message )
 {
-  desc_type desc{level, message};
-  diag_id id{diag_id( custom_diag_info.size() )};
+  desc_type desc{ level, message };
+  diag_id id{ diag_id( custom_diag_info.size() ) };
   custom_diag_ids.emplace( desc, id );
   custom_diag_info.emplace_back( desc );
   return diag_id( uint32_t( diag_id::NUM_STATIC_ERROR_IDS ) + uint32_t( id ) );
@@ -348,20 +348,20 @@ inline void diagnostic_engine::emit( diag_id id, std::vector<std::string> const&
 
 inline void diagnostic_engine::collect_single_msg( diag_id id, std::vector<std::string> const& args )
 {
-    std::pair<diag_id, std::vector<std::string>> collects_ids_args;
-    collects_ids_args.first = id;
-    collects_ids_args.second = args;
-    original_diag_ids_args.push_back( collects_ids_args );
+  std::pair<diag_id, std::vector<std::string>> collects_ids_args;
+  collects_ids_args.first = id;
+  collects_ids_args.second = args;
+  original_diag_ids_args.push_back( collects_ids_args );
 }
 
-inline void diagnostic_engine::collect_messages( const std::vector<std::pair<diag_id, std::vector<std::string>>>& original_diag_ids_args )
+inline void diagnostic_engine::collect_messages( std::vector<std::pair<diag_id, std::vector<std::string>>> const& original_diag_ids_args )
 {
   for ( auto i = 0; i < original_diag_ids_args.size(); i++ )
   {
-    auto item = original_diag_ids_args[i];
+    auto const item = original_diag_ids_args[i];
     lorina::diagnostic_level const level = lorina::diag_info[uint32_t( item.first )].first;
     std::string message = lorina::diag_info[uint32_t( item.first )].second;
-    auto args = item.second;
+    auto const args = item.second;
     for ( auto j = 0; j < args.size(); j++ )
     {
       message = fmt::format( message, args[j] );

--- a/lib/lorina/lorina/diagnostics.hpp
+++ b/lib/lorina/lorina/diagnostics.hpp
@@ -84,6 +84,13 @@ public:
    */
   virtual inline void emit( diag_id id, std::vector<std::string> const& args = {} ) const;
 
+  /*! \brief Collect a single message.
+   *
+   * \param id ID of diagnostic
+   * \param args Arguments
+   */
+  virtual inline void collect_single_msg( diag_id id, std::vector<std::string> const& args = {} );
+
   /*! \brief Create custom diagnostic.
    *
    * \param level Severity level
@@ -93,6 +100,9 @@ public:
 
   /*! \brief Return the number of emitted diagnostics. */
   uint64_t get_num_diagnostics() const;
+
+  /*! \brief Return the collected messages. */
+  std::string get_all_messages();
 
 private:
   /*! \brief Emit diagnostics with static ID.
@@ -109,11 +119,19 @@ private:
    */
   void emit_custom_diagnostic( diag_id id, std::vector<std::string> const& args ) const;
 
+  /*! \brief Collect all ids and messages
+   *
+   * \param original_diag_ids_args All pairs of the (id, message)
+   */
+  void collect_messages( std::vector<std::pair<diag_id, std::vector<std::string>>> original_diag_ids_args );
+
 protected:
   diagnostic_consumer *client_ = nullptr;  /*!< Diagnostic client. */
   std::vector<desc_type> custom_diag_info; /*!< Custom diagnostics. */
   std::map<desc_type, diag_id> custom_diag_ids; /*!< Map from custom ID to diagnostic. */
   mutable uint64_t num_diagnostics{0};
+  std::vector<std::pair<diag_id, std::vector<std::string>>> original_diag_ids_args;
+  std::string all_messages;
 }; /* diagnostic_engine */
 
 /*! \brief A builder for diagnostics.
@@ -227,6 +245,7 @@ inline diagnostic_builder::diagnostic_builder( diagnostic_engine& engine, diag_i
 inline diagnostic_builder::~diagnostic_builder()
 {
   engine_.emit( id_, args_ );
+  engine_.collect_single_msg( id_, args_ );
 }
 
 inline diagnostic_builder& diagnostic_builder::add_argument( std::string const& s )
@@ -252,6 +271,12 @@ inline diag_id diagnostic_engine::create_id( diagnostic_level level, std::string
 inline uint64_t diagnostic_engine::get_num_diagnostics() const
 {
   return num_diagnostics;
+}
+
+inline std::string diagnostic_engine::get_all_messages()
+{
+  collect_messages( original_diag_ids_args );
+  return all_messages;
 }
 
 inline diagnostic_builder diagnostic_engine::report( diag_id id )
@@ -317,6 +342,30 @@ inline void diagnostic_engine::emit( diag_id id, std::vector<std::string> const&
   else
   {
     emit_custom_diagnostic( id, args );
+  }
+}
+
+inline void diagnostic_engine::collect_single_msg( diag_id id, std::vector<std::string> const& args )
+{
+    std::pair<diag_id, std::vector<std::string>> collects_ids_args;
+    collects_ids_args.first = id;
+    collects_ids_args.second = args;
+    original_diag_ids_args.push_back( collects_ids_args );
+}
+
+inline void diagnostic_engine::collect_messages( std::vector<std::pair<diag_id, std::vector<std::string>>> original_diag_ids_args )
+{
+  for ( auto i = 0; i < original_diag_ids_args.size(); i++ )
+  {
+    auto item = original_diag_ids_args[i];
+    lorina::diagnostic_level const level = lorina::diag_info[uint32_t( item.first )].first;
+    std::string message = lorina::diag_info[uint32_t( item.first )].second;
+    auto args = item.second;
+    for ( auto j = 0; j < args.size(); j++ )
+    {
+      message = fmt::format( message, args[j] );
+    }
+    all_messages += ( message + "\n" );
   }
 }
 

--- a/lib/lorina/lorina/diagnostics.inc
+++ b/lib/lorina/lorina/diagnostics.inc
@@ -9,7 +9,9 @@ enum class diag_id
 
   /* AIGER */
   ERR_AIGER_HEADER,
+  ERR_AIGER_INPUT,
   ERR_AIGER_LATCH_DECLARATION,
+  ERR_AIGER_OUTPUT,
   ERR_AIGER_AND_DECLARATION,
 
   /* BLIF */
@@ -56,7 +58,9 @@ static std::pair<diagnostic_level, std::string> const diag_info[] = {
 
   /* AIGER */
   { diagnostic_level::fatal, "could not parse AIGER header `{}`" },
+  { diagnostic_level::fatal, "could not parse AIGER input `{}`" },
   { diagnostic_level::fatal, "could not parse declaration of LATCH `{}`" },
+  { diagnostic_level::fatal, "could not parse AIGER output `{}`" },
   { diagnostic_level::fatal, "could not parse declaration of AND gate `{}`" },
 
   /* BLIF */

--- a/test/io/aiger_reader.cpp
+++ b/test/io/aiger_reader.cpp
@@ -45,7 +45,75 @@ TEST_CASE( "read and write names", "[aiger_reader]" )
   CHECK( named_aig.get_output_name( 1 ) == "y1" );
 }
 
-TEST_CASE( "out-of-bounds index", "[aiger_reader]" )
+TEST_CASE( "header: Wrong number of items in header", "[aiger_reader]" )
+{
+  aig_network aig;
+
+  std::string file{ "aag 3 1 1\n"
+                    "2\n"
+                    "3\n"
+                    "7\n"
+                    "6 3 5\n" };
+
+  std::istringstream in( file );
+  lorina::text_diagnostics consumer;
+  lorina::diagnostic_engine diag( &consumer );
+  auto const result = lorina::read_ascii_aiger( in, aiger_reader( aig ), &diag );
+  CHECK( result == lorina::return_code::parse_error );
+}
+
+TEST_CASE( "header: negative number", "[aiger_reader]" )
+{
+  aig_network aig;
+
+  std::string file{ "aag 3 -2 0 1 1\n"
+                    "2\n"
+                    "3\n"
+                    "7\n"
+                    "6 3 5\n" };
+
+  std::istringstream in( file );
+  lorina::text_diagnostics consumer;
+  lorina::diagnostic_engine diag( &consumer );
+  auto const result = lorina::read_ascii_aiger( in, aiger_reader( aig ), &diag );
+  CHECK( result == lorina::return_code::parse_error );
+}
+
+TEST_CASE( "header: non-digit", "[aiger_reader]" )
+{
+  aig_network aig;
+
+  std::string file{ "aag 3 test 0 1 1\n"
+                    "2\n"
+                    "3\n"
+                    "7\n"
+                    "6 3 5\n" };
+
+  std::istringstream in( file );
+  lorina::text_diagnostics consumer;
+  lorina::diagnostic_engine diag( &consumer );
+  auto const result = lorina::read_ascii_aiger( in, aiger_reader( aig ), &diag );
+  CHECK( result == lorina::return_code::parse_error );
+}
+
+TEST_CASE( "output: out-of-bounds index", "[aiger_reader]" )
+{
+  aig_network aig;
+
+  std::string file{ "aag 3 2 0 1 1\n"
+                    "2\n"
+                    "3\n"
+                    "8\n"
+                    "6 3 5\n" };
+
+  std::istringstream in( file );
+  lorina::text_diagnostics consumer;
+  lorina::diagnostic_engine diag( &consumer );
+  auto const result = lorina::read_ascii_aiger( in, aiger_reader( aig ), &diag );
+  CHECK( result == lorina::return_code::parse_error );
+}
+
+TEST_CASE( "and: out-of-bounds index", "[aiger_reader]" )
 {
   aig_network aig;
 
@@ -56,11 +124,13 @@ TEST_CASE( "out-of-bounds index", "[aiger_reader]" )
                     "6 3 5\n" };
 
   std::istringstream in( file );
-  auto const result = lorina::read_ascii_aiger( in, aiger_reader( aig ) );
+  lorina::text_diagnostics consumer;
+  lorina::diagnostic_engine diag( &consumer );
+  auto const result = lorina::read_ascii_aiger( in, aiger_reader( aig ), &diag );
   CHECK( result == lorina::return_code::parse_error );
 }
 
-TEST_CASE( "negative index", "[aiger_reader]" )
+TEST_CASE( "and: negative index", "[aiger_reader]" )
 {
   aig_network aig;
 
@@ -71,7 +141,26 @@ TEST_CASE( "negative index", "[aiger_reader]" )
                     "6 3 5\n" };
 
   std::istringstream in( file );
-  auto const result = lorina::read_ascii_aiger( in, aiger_reader( aig ) );
+  lorina::text_diagnostics consumer;
+  lorina::diagnostic_engine diag( &consumer );
+  auto const result = lorina::read_ascii_aiger( in, aiger_reader( aig ), &diag );
+  CHECK( result == lorina::return_code::parse_error );
+}
+
+TEST_CASE( "and: non-digit", "[aiger_reader]" )
+{
+  aig_network aig;
+
+  std::string file{ "aag 3 2 0 1 1\n"
+                    "a\n"
+                    "3\n"
+                    "7\n"
+                    "6 3 5\n" };
+
+  std::istringstream in( file );
+  lorina::text_diagnostics consumer;
+  lorina::diagnostic_engine diag( &consumer );
+  auto const result = lorina::read_ascii_aiger( in, aiger_reader( aig ), &diag );
   CHECK( result == lorina::return_code::parse_error );
 }
 

--- a/test/io/aiger_reader.cpp
+++ b/test/io/aiger_reader.cpp
@@ -96,6 +96,51 @@ TEST_CASE( "header: non-digit", "[aiger_reader]" )
   CHECK( result == lorina::return_code::parse_error );
 }
 
+TEST_CASE( "input: out-of-bounds index", "[aiger_reader]" )
+{
+  aig_network aig;
+
+  std::string file{ "aag 1 1 0 1 0\n"
+                    "4\n"
+                    "3\n" };
+
+  std::istringstream in( file );
+  lorina::text_diagnostics consumer;
+  lorina::diagnostic_engine diag( &consumer );
+  auto const result = lorina::read_ascii_aiger( in, aiger_reader( aig ), &diag );
+  CHECK( result == lorina::return_code::parse_error );
+}
+
+TEST_CASE( "latch: out-of-bounds index of token 0", "[aiger_reader]" )
+{
+  sequential<aig_network> aig;
+
+  std::string file{ "aag 1 0 1 2 0\n"
+                    "1 3\n"
+                    "2\n"
+                    "3\n" };
+  std::istringstream in( file );
+  lorina::text_diagnostics consumer;
+  lorina::diagnostic_engine diag( &consumer );
+  auto const result = lorina::read_ascii_aiger( in, aiger_reader( aig ), &diag );
+  CHECK( result == lorina::return_code::parse_error );
+}
+
+TEST_CASE( "latch: out-of-bounds index of token 1", "[aiger_reader]" )
+{
+  sequential<aig_network> aig;
+
+  std::string file{ "aag 1 0 1 2 0\n"
+                    "2 4\n"
+                    "2\n"
+                    "3\n" };
+  std::istringstream in( file );
+  lorina::text_diagnostics consumer;
+  lorina::diagnostic_engine diag( &consumer );
+  auto const result = lorina::read_ascii_aiger( in, aiger_reader( aig ), &diag );
+  CHECK( result == lorina::return_code::parse_error );
+}
+
 TEST_CASE( "output: out-of-bounds index", "[aiger_reader]" )
 {
   aig_network aig;


### PR DESCRIPTION
# What
So the messages are collected here for aigverse.

# Why
Related to issue marcelwa/aigverse#130

# How
Since all final messages are printed and discarded after a single call to `report` function (trigger in `handle_diagnostic` function at the end), the messages of different level are not collected, so every time `emit` function is called, we collect the id, args and finally form all the messages.
